### PR TITLE
Update card handling to use bubble_card and enhance dropdown arrow styles

### DIFF
--- a/bonbon-strategy-builders.js
+++ b/bonbon-strategy-builders.js
@@ -54,7 +54,7 @@ export function createBuildersApi(panelUrl, config) {
   };
 
   const createButtonCard = (c, sectionConfig = {}, options = {}) => {
-    if (c?.object && !c?.bonbon_card) {
+    if (c?.object && !c?.bubble_card) {
       return c.object;
     }
     if (c?.entity?.entity_id?.startsWith('weather.') && sectionConfig.key == 'bonbon_weather') {
@@ -212,7 +212,12 @@ export function createBuildersApi(panelUrl, config) {
       }
     }
     const merged = { ...base, ...(options || {}) };
-    if (c?.object && c?.bonbon_card) {
+    if (c?.object && c?.bubble_card) {
+      console.log('yo');
+      console.log({
+        ...merged,
+        ...c.object,
+      });
       return {
         ...merged,
         ...c.object,

--- a/bonbon-strategy-entities.js
+++ b/bonbon-strategy-entities.js
@@ -451,13 +451,13 @@ export function createEntityApi(ctx = {}) {
                   });
                 }
               }
-            } else if ((c.entity_id || c.entity) && (context.entities[c.entity_id] || context.entities[c.entity])) {
+            } else if (!c?.selector && (c.entity_id || c.entity)) {
               elements.push({
-                bonbon_card: true,
+                bubble_card: c?.type == 'custom:bubble-card',
                 entity: context.entities[c.entity_id] || context.entities[c.entity],
                 object: c,
               });
-            } else if (c.entity && c.selector) {
+            } else if (c?.entity && c?.selector) {
               elements.push(c);
             } else {
               elements.push({ object: c });

--- a/bonbon-strategy-styles.js
+++ b/bonbon-strategy-styles.js
@@ -209,9 +209,14 @@ export function createStylesApi(panelUrl, config) {
           .is-off .bubble-main-icon {
             opacity: 1;
           }
+          .bubble-dropdown-arrow,
           .bubble-icon-container {
             --icon-primary-color: ${cssValue('icon-color-off')};
             background-color: ${cssValue('icon-background-off')};
+          }
+          .bubble-dropdown-arrow[style*='rotate(180deg)'] {
+            --icon-primary-color: ${cssValue('icon-color-off')} !important;
+            background-color: ${cssValue('icon-background-off')} !important;
           }
           ha-ripple {
             display: none !important;


### PR DESCRIPTION
Refactor card handling to utilize `bubble_card` instead of `bonbon_card` and improve styles for the dropdown arrow.